### PR TITLE
fixes daroczig/botor#18

### DIFF
--- a/R/s3.R
+++ b/R/s3.R
@@ -273,7 +273,7 @@ s3_ls <- function(uri) {
             size = object$data$Size,
             ## owner might be missing, so coerce NULL to NA
             owner = c(object$data$Owner$DisplayName, NA_character_)[1],
-            last_modified = object$data$LastModified$strftime('%Y-%m-%d %H:%M:%S %Z'),
+            last_modified = object$data$LastModified,
             stringsAsFactors = FALSE)
     }))
 


### PR DESCRIPTION
This was sufficient to resolve this bug report.

My session info:

```r
> sessioninfo::session_info()
─ Session info ────────────────────────────────────────────────────────────────────────────────────────────────────────────
 setting  value
 version  R version 4.4.0 (2024-04-24)
 os       macOS Sonoma 14.4.1
 system   aarch64, darwin20
 ui       RStudio
 language (EN)
 collate  en_US.UTF-8
 ctype    en_US.UTF-8
 tz       America/New_York
 date     2024-05-02
 rstudio  2024.04.0+735 Chocolate Cosmos (desktop)
 pandoc   NA

─ Packages ────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 ! package        * version    date (UTC) lib source
   assertthat       0.2.1      2019-03-21 [1] CRAN (R 4.4.0)
   backports        1.4.1      2021-12-13 [1] CRAN (R 4.4.0)
   boot             1.3-30     2024-02-26 [1] CRAN (R 4.4.0)
 P botor          * 0.4.0      2024-05-02 [?] Github (daroczig/botor@b095338)
   brio             1.1.5      2024-04-24 [1] CRAN (R 4.4.0)
   broom            1.0.5      2023-06-09 [1] CRAN (R 4.4.0)
   broom.helpers    1.15.0     2024-04-05 [1] CRAN (R 4.4.0)
   cachem           1.0.8      2023-05-01 [1] CRAN (R 4.4.0)
   callr            3.7.6      2024-03-25 [1] CRAN (R 4.4.0)
   checkmate        2.3.1      2023-12-04 [1] CRAN (R 4.4.0)
   cli              3.6.2      2023-12-11 [1] CRAN (R 4.4.0)
   colorspace       2.1-0      2023-01-23 [1] CRAN (R 4.4.0)
   countrycode    * 1.6.0      2024-03-22 [1] CRAN (R 4.4.0)
   curl             5.2.1      2024-03-01 [1] CRAN (R 4.4.0)
   data.table       1.15.4     2024-03-30 [1] CRAN (R 4.4.0)
   desc             1.4.3      2023-12-10 [1] CRAN (R 4.4.0)
   devtools         2.4.5      2022-10-11 [1] CRAN (R 4.4.0)
   digest           0.6.35     2024-03-11 [1] CRAN (R 4.4.0)
   dplyr          * 1.1.4      2023-11-17 [1] CRAN (R 4.4.0)
   DT               0.33       2024-04-04 [1] CRAN (R 4.4.0)
   ellipsis         0.3.2      2021-04-29 [1] CRAN (R 4.4.0)
   fansi            1.0.6      2023-12-08 [1] CRAN (R 4.4.0)
   fastmap          1.1.1      2023-02-24 [1] CRAN (R 4.4.0)
   fontawesome      0.5.2      2023-08-19 [1] CRAN (R 4.4.0)
   forcats        * 1.0.0      2023-01-29 [1] CRAN (R 4.4.0)
   formatR          1.14       2023-01-17 [1] CRAN (R 4.4.0)
   fs               1.6.4      2024-04-25 [1] CRAN (R 4.4.0)
   futile.logger    1.4.3      2016-07-10 [1] CRAN (R 4.4.0)
   futile.options   1.0.1      2018-04-20 [1] CRAN (R 4.4.0)
   generics         0.1.3      2022-07-05 [1] CRAN (R 4.4.0)
   ggplot2        * 3.5.1      2024-04-23 [1] CRAN (R 4.4.0)
   glue             1.7.0      2024-01-09 [1] CRAN (R 4.4.0)
   gt               0.10.1     2024-01-17 [1] CRAN (R 4.4.0)
   gtable           0.3.5      2024-04-22 [1] CRAN (R 4.4.0)
   gtExtras         0.5.0      2023-09-15 [1] CRAN (R 4.4.0)
   gtsummary        1.7.2      2023-07-15 [1] CRAN (R 4.4.0)
   here             1.0.1      2020-12-13 [1] CRAN (R 4.4.0)
   hms              1.1.3      2023-03-21 [1] CRAN (R 4.4.0)
   htmltools        0.5.8.1    2024-04-04 [1] CRAN (R 4.4.0)
   htmlwidgets      1.6.4      2023-12-06 [1] CRAN (R 4.4.0)
   httpcache        1.2.0      2021-01-10 [1] CRAN (R 4.4.0)
   httpuv           1.6.15     2024-03-26 [1] CRAN (R 4.4.0)
   httr             1.4.7      2023-08-15 [1] CRAN (R 4.4.0)
   jsonlite         1.8.8      2023-12-04 [1] CRAN (R 4.4.0)
   keyring          1.3.2      2023-12-11 [1] CRAN (R 4.4.0)
   knitr            1.46       2024-04-06 [1] CRAN (R 4.4.0)
   lambda.r         1.2.4      2019-09-18 [1] CRAN (R 4.4.0)
   later            1.3.2      2023-12-06 [1] CRAN (R 4.4.0)
   lattice          0.22-6     2024-03-20 [1] CRAN (R 4.4.0)
   lifecycle        1.0.4      2023-11-07 [1] CRAN (R 4.4.0)
   logger           0.3.0      2024-03-05 [1] CRAN (R 4.4.0)
   lubridate      * 1.9.3      2023-09-27 [1] CRAN (R 4.4.0)
   magrittr         2.0.3      2022-03-30 [1] CRAN (R 4.4.0)
   Matrix           1.7-0      2024-03-22 [1] CRAN (R 4.4.0)
   memoise          2.0.1      2021-11-26 [1] CRAN (R 4.4.0)
   mime             0.12       2021-09-28 [1] CRAN (R 4.4.0)
   miniUI           0.1.1.1    2018-05-18 [1] CRAN (R 4.4.0)
   munsell          0.5.1      2024-04-01 [1] CRAN (R 4.4.0)
   paletteer        1.6.0      2024-01-21 [1] CRAN (R 4.4.0)
   pillar           1.9.0      2023-03-22 [1] CRAN (R 4.4.0)
   pkgbuild         1.4.4      2024-03-17 [1] CRAN (R 4.4.0)
   pkgconfig        2.0.3      2019-09-22 [1] CRAN (R 4.4.0)
   pkgload          1.3.4      2024-01-16 [1] CRAN (R 4.4.0)
   png              0.1-8      2022-11-29 [1] CRAN (R 4.4.0)
   processx         3.8.4      2024-03-16 [1] CRAN (R 4.4.0)
   profvis          0.3.8      2023-05-02 [1] CRAN (R 4.4.0)
   promises         1.3.0      2024-04-05 [1] CRAN (R 4.4.0)
   ps               1.7.6      2024-01-18 [1] CRAN (R 4.4.0)
   purrr          * 1.0.2      2023-08-10 [1] CRAN (R 4.4.0)
   R6               2.5.1      2021-08-19 [1] CRAN (R 4.4.0)
   Rcpp             1.0.12     2024-01-09 [1] CRAN (R 4.4.0)
   readr          * 2.1.5      2024-01-10 [1] CRAN (R 4.4.0)
   rematch2         2.1.2      2020-05-01 [1] CRAN (R 4.4.0)
   remotes          2.5.0      2024-03-17 [1] CRAN (R 4.4.0)
   reticulate       1.36.1     2024-04-22 [1] CRAN (R 4.4.0)
   
─ Python configuration ────────────────────────────────────────────────────────────────────────────────────────────────────
 python:         /Users/jacquelineburos/.virtualenvs/r-reticulate/bin/python
 libpython:      /Users/jacquelineburos/.pyenv/versions/3.10.7/lib/libpython3.10.dylib
 pythonhome:     /Users/jacquelineburos/.virtualenvs/r-reticulate:/Users/jacquelineburos/.virtualenvs/r-reticulate
 version:        3.10.7 (main, Jan 23 2024, 18:44:29) [Clang 14.0.3 (clang-1403.0.22.14.1)]
 numpy:          /Users/jacquelineburos/.virtualenvs/r-reticulate/lib/python3.10/site-packages/numpy
 numpy_version:  1.26.3
 xarray:         /Users/jacquelineburos/.virtualenvs/r-reticulate/lib/python3.10/site-packages/xarray

```